### PR TITLE
Fixing mockProvider, adding support for ng-annotate

### DIFF
--- a/src/quickmock.js
+++ b/src/quickmock.js
@@ -31,6 +31,11 @@
 				var currProviderName = providerData[2][0];
 				if(currProviderName === opts.providerName){
 					var currProviderDeps = providerData[2][1];
+
+                    if (angular.isFunction(currProviderDeps)) {
+                        currProviderDeps = currProviderDeps.$inject || injector.annotate(currProviderDeps);
+                    }
+
 					for(var i=0; i<currProviderDeps.length - 1; i++){
 						var depName = currProviderDeps[i];
 						mocks[depName] = getMockForProvider(depName, currProviderDeps, i);


### PR DESCRIPTION
Hello, I'm starting to use this awesome library, but I had this issue with the mockProvider, because I declare my services like below, and use webpack ng-annotate-loader, who creates Api.$inject where are the currProviderDeps.

/*\* @ngInject */
function Api($http, $state, $ionicLoading, $ionicHistory, $ionicPopup) {}
