### PR TITLE
feat: don't mock dependencies that angular-mocks already handles well

### DIFF
--- a/src/quickmock.js
+++ b/src/quickmock.js
@@ -1,5 +1,7 @@
 (function(angular){
 
+	var NO_MOCK = ['$http', '$timeout', '$q'];
+	
 	var opts, mockPrefix;
 
 	quickmock.MOCK_PREFIX = mockPrefix = (quickmock.MOCK_PREFIX || '___');
@@ -38,6 +40,10 @@
 
 					for(var i=0; i<currProviderDeps.length - 1; i++){
 						var depName = currProviderDeps[i];
+						if(NO_MOCK.indexOf(depName) >= 0){
+							continue;	
+						}
+						
 						mocks[depName] = getMockForProvider(depName, currProviderDeps, i);
 					}
 				}


### PR DESCRIPTION
@tennisgent, so while I love what quickmock does, I've found it difficult to work when it tries to mock things that are already handled (mostly $httpBackend). I'd rather just use those mocks by default.
