### PR TITLE
Fixed a bug affecting constants and values

### DIFF
--- a/src/quickmock.js
+++ b/src/quickmock.js
@@ -146,20 +146,26 @@
 	}
 
 	function sanitizeProvider(providerData, injector){
-		if(angular.isString(providerData[2][0]) && providerData[2][0].indexOf(mockPrefix) === -1){
-			if(angular.isFunction(providerData[2][1])){
+		var providerType = providerData[1];
+		var providerName = providerData[2][0];
+		var providerDependencies = providerData[2][1];
+		if(angular.isString(providerName) && providerName.indexOf(mockPrefix) === -1){
+			if(angular.isFunction(providerDependencies)){
 				// provider declaration function has been provided without the array annotation,
 				// so we need to annotate it so the invokeQueue can be prefixed
-				var annotatedDependencies = injector.annotate(providerData[2][1]);
-				delete providerData[2][1].$inject;
-				annotatedDependencies.push(providerData[2][1]);
+				var annotatedDependencies = injector.annotate(providerDependencies);
+				delete providerDependencies.$inject;
+				annotatedDependencies.push(providerDependencies);
 				providerData[2][1] = annotatedDependencies;
 			}
-			var currProviderDeps = providerData[2][1];
-			if(angular.isArray(currProviderDeps)){
-				for(var i=0; i<currProviderDeps.length - 1; i++){
-					if(currProviderDeps[i].indexOf(mockPrefix) === 0){
-						currProviderDeps[i] = currProviderDeps[i].replace(mockPrefix, '');
+			providerDependencies = providerData[2][1];
+			if(angular.isArray(providerDependencies) && providerType !== 'constant' && providerType !== 'value'){
+				// We don't want this code getting run if the provider is a constant or value, because an array is valid
+				// as a constant or value. Constants and values do *not* use the array syntax for dependencies, because
+				// they can't take dependencies.
+				for(var i=0; i<providerDependencies.length - 1; i++){
+					if(providerDependencies[i].indexOf(mockPrefix) === 0){
+						providerDependencies[i] = providerDependencies[i].replace(mockPrefix, '');
 					}
 				}
 			}

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -20,6 +20,8 @@
 	<!-- include spec files here... -->
 	<script src="general-providers.spec.js"></script>
 	<script src="directive-providers.spec.js"></script>
+	<script src="constant-providers.spec.js"></script>
+	<script src="value-providers.spec.js"></script>
 
 </head>
 

--- a/test/constant-providers.spec.js
+++ b/test/constant-providers.spec.js
@@ -1,0 +1,22 @@
+(function () {
+    describe('Constant provider', function () {
+        angular.module('ConstantProvidersTestModule', [])
+            .constant('FakeConstant', [
+                { id: 1, name: 'One' },
+                { id: 2, name: 'Two' },
+                { id: 3, name: 'Three' }
+            ])
+            .service('FakeService', ['FakeConstant', function (fakeConstant) {
+                return { myConstant: fakeConstant };
+            }]);
+
+        it('does not throw when attempting to be injected', function () {
+            expect(function () {
+                quickmock({
+                    providerName: 'FakeService',
+                    moduleName: 'ConstantProvidersTestModule'
+                });
+            }).not.toThrow();
+        });
+    });
+}());

--- a/test/value-providers.spec.js
+++ b/test/value-providers.spec.js
@@ -1,0 +1,22 @@
+(function () {
+    describe('Value provider', function () {
+        angular.module('ValueProvidersTestModule', [])
+            .constant('FakeValue', [
+                { id: 1, name: 'One' },
+                { id: 2, name: 'Two' },
+                { id: 3, name: 'Three' }
+            ])
+            .service('FakeService', ['FakeValue', function (fakeValue) {
+                return { myValue: fakeValue };
+            }]);
+
+        it('does not throw when attempting to be injected', function () {
+            expect(function () {
+                quickmock({
+                    providerName: 'FakeService',
+                    moduleName: 'ValueProvidersTestModule'
+                });
+            }).not.toThrow();
+        });
+    });
+}());


### PR DESCRIPTION
Constants and values are allowed to be defined as arrays. When defining
either as an array, QuickMock would incorrectly assume that we were
trying to denote dependencies. Dependencies cannot, however, be defined
for constants and values in this manner.